### PR TITLE
feat: enhance APIs and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,22 @@ This will start the development server with auto-reloading and an instant previe
 *   **Backend for Minting:** The minting of CareCoins upon charting is designed to be handled by a secure backend service. The frontend currently simulates this interaction by making a `fetch` call to a hypothetical `/api/mint-carecoin` endpoint. You will need to implement this backend service separately.
 
 ## How to Contribute
+Contributions are welcome!
 
-(Add your contribution guidelines here)
+1. Fork the repository and create your branch from `main`.
+2. Install dependencies with `npm install`.
+3. Run `npm run lint` and `npm run build` to verify your changes.
+4. Submit a pull request with a clear description.
 
 ## Deployment
 
-(Add your deployment instructions here)
+1. Build the production assets:
+   ```sh
+   npm run build
+   ```
+   The output will be located in the `dist` directory.
+2. Preview the build locally:
+   ```sh
+   npm run preview
+   ```
+3. Deploy the contents of `dist` to your preferred static hosting provider (e.g., Netlify, Vercel). Ensure that required environment variables are configured on the host.

--- a/src/lib/api/chartApi.ts
+++ b/src/lib/api/chartApi.ts
@@ -23,6 +23,30 @@ export const chartApi = {
     }));
   },
 
+  async getChartRecordById(id: string): Promise<ChartRecord | null> {
+    const { data, error } = await supabase
+      .from('chart_records')
+      .select('*')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (error) {
+      console.error('Error fetching chart record:', error);
+      throw error;
+    }
+
+    if (!data) {
+      return null;
+    }
+
+    return {
+      ...data,
+      vital_signs: data.vital_signs as Record<string, unknown> || {},
+      vitals: data.vitals as Record<string, unknown> || {},
+      medications: data.medications as Record<string, unknown> || {}
+    };
+  },
+
   async createChartRecord(record: Omit<ChartRecord, 'created_at' | 'id'>): Promise<ChartRecord> {
     const recordData = {
       ...record,

--- a/src/lib/supabaseApi.ts
+++ b/src/lib/supabaseApi.ts
@@ -27,10 +27,7 @@ export const getPatientCharts = chartApi.chartApi.getChartRecords;
 export const addChartRecord = chartApi.chartApi.createChartRecord;
 export const updateChartRecord = chartApi.chartApi.updateChartRecord;
 export const createChartRecord = chartApi.chartApi.createChartRecord;
-export const getChartRecordById = async (id: string) => {
-  // Mock implementation since this function doesn't exist
-  return null;
-};
+export const getChartRecordById = chartApi.chartApi.getChartRecordById;
 export const getChartRecordsByPatientId = chartApi.chartApi.getChartRecords;
 export const deleteChartRecord = chartApi.chartApi.deleteChartRecord;
 
@@ -59,8 +56,12 @@ export const transferCareCoins = async (fromId: string, toId: string, amount: nu
 };
 
 export const getCareCoinsBalance = async (userId: string) => {
-  // Mock implementation
-  return 100;
+  const transactions = await careCoinsApi.careCoinsApi.getTransactions(userId);
+  return transactions.reduce((balance, tx) => {
+    if (tx.to_user_id === userId) return balance + tx.amount;
+    if (tx.from_user_id === userId) return balance - tx.amount;
+    return balance;
+  }, 0);
 };
 
 export const {

--- a/src/lib/web3.ts
+++ b/src/lib/web3.ts
@@ -34,6 +34,11 @@ export const storeContractAddress = (address: string, abi: string[]): void => {
   localStorage.setItem('carecoin_contract_abi', JSON.stringify(abi));
 };
 
+export const clearStoredContract = (): void => {
+  localStorage.removeItem('carecoin_contract_address');
+  localStorage.removeItem('carecoin_contract_abi');
+};
+
 export const getStoredContractABI = (): string[] => {
   const stored = localStorage.getItem('carecoin_contract_abi');
   return stored ? JSON.parse(stored) : [


### PR DESCRIPTION
## Summary
- add chart record lookup by id and wire through supabase API
- compute CareCoin balances from user transactions
- document contribution workflow and deployment steps
- add helper to clear stored CareCoin contract info

## Testing
- `npm run lint` *(fails: Unexpected any in existing Supabase functions)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fce0abb3c8326b1c30df4bf4f25cc